### PR TITLE
WallManager: Reset of the MoleSpawnOrder

### DIFF
--- a/Assets/Scripts/Game/GameDirector.cs
+++ b/Assets/Scripts/Game/GameDirector.cs
@@ -124,6 +124,11 @@ public class GameDirector : MonoBehaviour
 
     }
 
+    private void ResetMoleSpawnOrder()
+    {
+        wallManager.ResetMoleSpawnOrder();
+    }
+
     void Start()
     {
 
@@ -225,6 +230,7 @@ public class GameDirector : MonoBehaviour
             {"GameState", System.Enum.GetName(typeof(GameDirector.GameState), gameState)}
         });
         ResetPointerShootOrder();
+        ResetMoleSpawnOrder();
         FinishGame();
     }
 

--- a/Assets/Scripts/Game/GameDirector.cs
+++ b/Assets/Scripts/Game/GameDirector.cs
@@ -82,6 +82,7 @@ public class GameDirector : MonoBehaviour
     public TestChangeEvent testChanged = new TestChangeEvent();
     private int participantId = 0;
     private int testId = 0;
+    private Pointer[] allPointers;
 
     private Dictionary<string, Dictionary<string, float>> difficulties = new Dictionary<string, Dictionary<string, float>>(){
         {"Slow", new Dictionary<string, float>(){
@@ -110,6 +111,17 @@ public class GameDirector : MonoBehaviour
         modifiersManager = FindObjectOfType<ModifiersManager>();
         gameDefaultDuration = gameDuration;
         constraint = FindObjectOfType<Constraint>();
+    }
+
+    private void ResetPointerShootOrder()
+    {
+        allPointers = FindObjectsOfType<Pointer>();
+
+        foreach (var pointer in allPointers)
+        {
+            pointer.ResetShootOrder();
+        }
+
     }
 
     void Start()
@@ -212,6 +224,7 @@ public class GameDirector : MonoBehaviour
         {
             {"GameState", System.Enum.GetName(typeof(GameDirector.GameState), gameState)}
         });
+        ResetPointerShootOrder();
         FinishGame();
     }
 

--- a/Assets/Scripts/Game/WallManager.cs
+++ b/Assets/Scripts/Game/WallManager.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Events;
+using Valve.VR.InteractionSystem;
 
 /*
 Spawns, references and activates the moles. Is the only component to directly interact with the moles.
@@ -557,5 +558,12 @@ public class WallManager : MonoBehaviour
             Clear();
             Enable();
         }
+    }
+
+    public void ResetMoleSpawnOrder()
+    {
+        spawnOrder = 0;
+        moles.Values.ForEach(m => m.SetSpawnOrder(-1));
+        moleCount = 0;
     }
 }

--- a/Assets/Scripts/Pointers/Pointer.cs
+++ b/Assets/Scripts/Pointers/Pointer.cs
@@ -139,6 +139,15 @@ public abstract class Pointer : MonoBehaviour
         }
     }
 
+    public void ResetShootOrder()
+    {
+        pointerShootOrder = -1;
+        loggerNotifier.NotifyLogger(overrideEventParameters: new Dictionary<string, object>()
+        {
+            {"PointerShootOrder", "NULL"}
+        });
+    }
+
     public void SetPerformanceFeedback(bool perf) {
         performancefeedback = perf;
     }


### PR DESCRIPTION
MoleSpawnOrder was not reset to 0 when we started a new game
Creation of a function ResetMoleSpawnOrder